### PR TITLE
fix: update imported class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ x-locust-import:
 The `locustfile.py` will have the following imports:
 
 ```.py
-from locust import HttpLocust, TaskSet, task
+from locust import HttpUser, TaskSet, task
 import time
 
 class MyTaskSet(TaskSet):

--- a/lib/swagger2locust.js
+++ b/lib/swagger2locust.js
@@ -85,7 +85,7 @@ module.exports = {
   // Outputs a locustfile header (including class def)
   locustfileHeader : function(options) {
     var header = ""
-    header += "from locust import HttpLocust, TaskSet, task\n"
+    header += "from locust import HttpUser, TaskSet, task\n"
     if (options["x-locust-import"]) {
       for (imp in options["x-locust-import"]) {
         header += "import "+options["x-locust-import"][imp]+"\n";
@@ -100,8 +100,8 @@ module.exports = {
   // Outputs the locust class and the settings (host, min, max, etc).
   locustfileFooter : function(options) {
     var footer = ""
-    footer += "class MyLocust(HttpLocust):\n"
-    footer += "    task_set = MyTaskSet\n"
+    footer += "class MyLocust(HttpUser):\n"
+    footer += "    tasks = [MyTaskSet]\n"
     for(currOpt in options){
       if (currOpt == "host") {
         footer += "    "+currOpt+' = "'+options[currOpt]+'"'+"\n"


### PR DESCRIPTION
This should fix #15.

Seems to work locally:

```
locust -f locustfile.py -H http://localhost:8000
[2022-07-13 18:58:04,636] ./INFO/locust.main: Starting web interface at http://0.0.0.0:8089 (accepting connections from all network interfaces)
[2022-07-13 18:58:04,642] ./INFO/locust.main: Starting Locust 2.10.1
[2022-07-13 18:58:20,205] ./INFO/locust.runners: Ramping to 1 users at a rate of 1.00 per second
[2022-07-13 18:58:20,209] .INFO/locust.runners: All users spawned: {"MyLocust": 1} (1 total users)
[2022-07-13 18:58:34,568] ./INFO/locust.runners: Ramping to 1 users at a rate of 1.00 per second
[2022-07-13 18:58:34,569] ./INFO/locust.runners: All users spawned: {"MyLocust": 1} (1 total users)
KeyboardInterrupt
2022-07-13T22:58:48Z
[2022-07-13 18:58:48,833] ./INFO/locust.main: Shutting down (exit code 1) 
Type     Name               # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|-----------------|-------|-------------|-------|-------|-------|-------|--------|-----------
GET      /foo                 153 153(100.00%) |      1       0      11      1 |   92.73       92.73
```